### PR TITLE
fix: return using Nuxt/h3 createError function

### DIFF
--- a/server/api/send.ts
+++ b/server/api/send.ts
@@ -13,6 +13,9 @@ export default defineEventHandler(async () => {
 
     return data;
   } catch (error) {
-    return { error };
+    return createError({
+      statusCode: 500,
+      message: 'Error sending email'
+    })
   }
 });


### PR DESCRIPTION
I know this is an example, but I think many people would just copy it. I though it might be better to send a proper HTTP error instead of 200.