### PR TITLE
feat(server/utils): separate utils

### DIFF
--- a/server/api/send.ts
+++ b/server/api/send.ts
@@ -1,7 +1,3 @@
-import { Resend } from 'resend';
-
-const resend = new Resend(process.env.RESEND_API_KEY);
-
 export default defineEventHandler(async () => {
   try {
     const data = await resend.emails.send({

--- a/server/utils/resend.ts
+++ b/server/utils/resend.ts
@@ -1,0 +1,3 @@
+import { Resend } from 'resend';
+
+export default new Resend(process.env.RESEND_API_KEY);


### PR DESCRIPTION
This PR cleans up our code by **moving the Resend setup to its own utility file**, `server/utils/resend.ts`. We're now importing the `Resend` instance from there for all server-side operations, rather than initializing it directly in `server/api/send.ts`. This makes our code **more organized and reusable**, which is a better way to structure our Nuxt app.